### PR TITLE
Fix some typos in amend.mdx

### DIFF
--- a/my-website/docs/concepts/amend.mdx
+++ b/my-website/docs/concepts/amend.mdx
@@ -79,7 +79,7 @@ q)L . enlist 1		// returning element 1 of the list, i.e. L@1
 11 12
 q)L . 1 2		// returning element 2 of element 1, i.e (L@1) @2
 11 12
-q)L . 1 2 0		// returning element 0 of element 2 of elment 1, i.e ((L@1) @2) @0
+q)L . 1 2 0		// returning element 0 of element 2 of element 1, i.e ((L@1) @2) @0
 11
 ```
 
@@ -180,7 +180,7 @@ q)L . (::;0 1)
 13 14 15 16 17 18
 ```
 
-We can extend this behaviour to one more level
+We can extend this behaviour to one more level:
 ```
 // First we select all elements of element 2 and elment 0
 q)L . (2 0;::)
@@ -192,11 +192,11 @@ q)L . (2 0;::;0 1)
 (1 2;4 5)
 ```
 
-If you would like to explorer indexing further, please review the official documentation [here](https://code.kx.com/q/ref/apply/)
+If you would like to explore indexing further, please review the official documentation [here](https://code.kx.com/q/ref/apply/)
 
 ### Apply
 
-When it comes to (function) application, the `@ and .` are basically syntactic sugar and can be used instead of bracket notation. Given an unary function `f` and a one-element list `ux`, the code `f@ux` is equivalent to `f[ux]`. Let's look at an example. Multivalent functions on the other hand, can be used in combination with the `.` operator. Given a multivalent function `f` and a list of arguments vx, the code `f[vx[0];vx[1];...;vx[n-1]]` is equivalent to `f . vx`.
+When it comes to (function) application, the `@ and .` are basically syntactic sugar, and can be used instead of bracket notation. Given an unary function `f` and a one-element list `ux`, the code `f@ux` is equivalent to `f[ux]`. Let's look at an example. Multivalent functions on the other hand, can be used in combination with the `.` operator. Given a multivalent function `f` and a list of arguments vx, the code `f[vx[0];vx[1];...;vx[n-1]]` is equivalent to `f . vx`.
 
 ### Unary functions
 
@@ -221,7 +221,7 @@ In the case of `f[3]` the brackets around the argument are also syntactic sugar.
 
 ### Multivalent functions
 
-Multivalent functions are functions that take two or more arguments. The application of a list of arguments to a multivalent function can be achieved as follows
+Multivalent functions are functions that take two or more arguments. The application of a list of arguments to a multivalent function can be achieved as follows:
 
 ```
 q)f:{x+y}
@@ -410,7 +410,7 @@ If `v` is Assign `(:)` each item in the selection is replaced by the correspondi
 
 ### Bonus Tip
 
-When going through the examples of Amend on the official reference page [here](https://code.kx.com/q/ref/amend/#amend-entire) I encountered below code snippet, and it took me a little while to fully understand what was going on. So let me explain what's happening in case you are acing the same struggle
+When going through the examples of Amend on the official reference page [here](https://code.kx.com/q/ref/amend/#amend-entire) I encountered below code snippet, and it took me a little while to fully understand what was going on. So let me explain what's happening in case you are facing the same struggle
 
 ```
 q).[1 2; (); 3 4 5]


### PR DESCRIPTION
Thanks for the article!

I went to add the link to https://code.kx.com/q/ref/amend/ that was implied in the text, because [the page](https://www.defconq.tech/docs/concepts/amend) didn't have it, but it turns out that the markdown renderer just didn't generate it.